### PR TITLE
fix: supporting calculate commp of file with larger than 32G size.

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -145,7 +145,7 @@ func (w *Writer) Sum() (DataCIDSize, error) {
 		}
 	}
 
-	p, err := ffi.GenerateUnsealedCID(abi.RegisteredSealProof_StackedDrg32GiBV1, pieces)
+	p, err := ffi.GenerateUnsealedCID(abi.RegisteredSealProof_StackedDrg64GiBV1, pieces)
 	if err != nil {
 		return DataCIDSize{}, xerrors.Errorf("generating unsealed CID: %w", err)
 	}


### PR DESCRIPTION
fix: supporting calculate commp of file with larger than 32G size.