### PR TITLE
ci: explicitly switch macos build to silicon and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
   build-macos:
     description: build with Darwin
     macos:
-      xcode: "10.0.0"
+      xcode: "15.0.0"
+    resource_class: macos.x86.medium.gen2
     working_directory: ~/go/src/github.com/filecoin-project/go-commp-utils
     steps:
       - prepare:


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.

Since the project is currently not configured to build on CircleCI, I didn't verify if the introduced changes work as expected. Some additional changes might be required. Example of such changes from other repos - https://github.com/filecoin-project/go-sectorbuilder/pull/97/files.