### PR TITLE
fix: augment PieceAggregateCommP to return the resulting aggregate size

### DIFF
--- a/commd.go
+++ b/commd.go
@@ -111,7 +111,7 @@ func PieceAggregateCommP(proofType abi.RegisteredSealProof, pieceInfos []abi.Pie
 
 	fincid, err := commcid.PieceCommitmentV1ToCID(stack[0].commP)
 
-	return fincid, abi.PaddedPieceSize(stack[0].size), err
+	return fincid, abi.PaddedPieceSize(stack[0].size / 2), err
 }
 
 var s256pool = sync.Pool{New: func() any { return sha256simd.New() }}

--- a/commd.go
+++ b/commd.go
@@ -111,7 +111,7 @@ func PieceAggregateCommP(proofType abi.RegisteredSealProof, pieceInfos []abi.Pie
 
 	fincid, err := commcid.PieceCommitmentV1ToCID(stack[0].commP)
 
-	return fincid, abi.PaddedPieceSize(stack[0].size / 2), err
+	return fincid, abi.PaddedPieceSize(stack[0].size), err
 }
 
 var s256pool = sync.Pool{New: func() any { return sha256simd.New() }}

--- a/commd_test.go
+++ b/commd_test.go
@@ -26,7 +26,7 @@ func TestGenerateUnsealedCID(t *testing.T) {
 
 	expCommD := cidMustParse("baga6ea4seaqiw3gbmstmexb7sqwkc5r23o3i7zcyx5kr76pfobpykes3af62kca")
 
-	commD, _ := commp.PieceAggregateCommP(
+	commD, _, _ := commp.PieceAggregateCommP(
 		abi.RegisteredSealProof_StackedDrg32GiBV1_1, // 32G sector SP
 		[]abi.PieceInfo{
 			{PieceCID: cidMustParse("baga6ea4seaqknzm22isnhsxt2s4dnw45kfywmhenngqq3nc7jvecakoca6ksyhy"), Size: 256 << 20},  // https://filfox.info/en/deal/3755444

--- a/commd_test.go
+++ b/commd_test.go
@@ -26,7 +26,7 @@ func TestGenerateUnsealedCID(t *testing.T) {
 
 	expCommD := cidMustParse("baga6ea4seaqiw3gbmstmexb7sqwkc5r23o3i7zcyx5kr76pfobpykes3af62kca")
 
-	commD, _, _ := commp.PieceAggregateCommP(
+	commD, sizeD, _ := commp.PieceAggregateCommP(
 		abi.RegisteredSealProof_StackedDrg32GiBV1_1, // 32G sector SP
 		[]abi.PieceInfo{
 			{PieceCID: cidMustParse("baga6ea4seaqknzm22isnhsxt2s4dnw45kfywmhenngqq3nc7jvecakoca6ksyhy"), Size: 256 << 20},  // https://filfox.info/en/deal/3755444
@@ -48,6 +48,10 @@ func TestGenerateUnsealedCID(t *testing.T) {
 
 	if commD != expCommD {
 		t.Fatalf("calculated commd for sector f01392893:139074 as %s, expected %s", commD, expCommD)
+	}
+
+	if sizeD != 32<<30 {
+		t.Fatalf("calculated size for sector f01392893:139074 as %d, expected 32GiB", sizeD)
 	}
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -143,14 +143,14 @@ func (w *Writer) Sum() (DataCIDSize, error) {
 		}
 	}
 
-	p, err := commp.PieceAggregateCommP(abi.RegisteredSealProof_StackedDrg64GiBV1, pieces)
+	p, sz, err := commp.PieceAggregateCommP(abi.RegisteredSealProof_StackedDrg64GiBV1, pieces)
 	if err != nil {
 		return DataCIDSize{}, xerrors.Errorf("generating unsealed CID: %w", err)
 	}
 
 	return DataCIDSize{
 		PayloadSize: rawLen,
-		PieceSize:   abi.PaddedPieceSize(len(leaves)) * commPBufPad,
+		PieceSize:   sz,
 		PieceCID:    p,
 	}, nil
 }


### PR DESCRIPTION
Arguably this is an API-breaking change. But:

1. We just shipped this yesterday
2. The code is more than straightforward
3. It allows one to do this downstream: https://github.com/filecoin-project/lotus/pull/12345/commits/934782f0e4b267d70c5b0007a521dca9e3161696#diff-94056d08269ce546601aa645389b4f81f2293af990d4c3a79094629b121723e6

